### PR TITLE
using get_list instead of get_env

### DIFF
--- a/sharespots/settings/base.py
+++ b/sharespots/settings/base.py
@@ -4,6 +4,7 @@ import django_heroku
 
 from env_utils import (
     get_env,
+    get_list,
 )
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)

--- a/sharespots/settings/production.py
+++ b/sharespots/settings/production.py
@@ -5,4 +5,4 @@ DEBUG = False
 
 # access heroku environment environment-variable (config variable) of the secret key
 SECRET_KEY = get_env('SECRET_KEY')
-ALLOWED_HOSTS = get_env('ALLOWED_HOSTS')
+ALLOWED_HOSTS = get_list('ALLOWED_HOSTS', separator=',')


### PR DESCRIPTION
### What change does this PR introduce?

get_list is used to get `ALLOWED_HOSTS` from environment

### Notes

_Instructions on how to run this locally, background context, what to review, questions…_

### Ticket

- [Trello Ticket]()

### Screenshots

_Visuals that may help the reviewer_
