### PR TITLE
feat: disable the allowed_hosts config from heroku django package & enable logging always

### DIFF
--- a/sharespots/settings/base.py
+++ b/sharespots/settings/base.py
@@ -131,9 +131,7 @@ STATICFILES_DIRS = (
 )
 
 # Activate Django-Heroku.
-django_heroku.settings(locals(), logging=not DEBUG, databases=not DEBUG)
-
-
+django_heroku.settings(locals(), logging=True, allowed_hosts=False, databases=not DEBUG)
 
 NOTEBOOK_ARGUMENTS = [
     '--ip', '0.0.0.0',


### PR DESCRIPTION
### What change does this PR introduce?
Allows the website to log any issues to heroku logs.
### Ticket

- [Trello Ticket](https://trello.com/c/t4FMkLpr/94-add-django-logging-so-we-can-see-errors-in-production-mode-too)
