### PR TITLE
Feature/venue geocode

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -34,7 +34,20 @@ class Venue(models.Model):
     coffee = models.OneToOneField('Rating', on_delete=models.CASCADE, null=True, related_name='coffee')
     slogan = models.CharField(max_length=250, null=True)
     image = models.URLField(max_length=200, null=True)
+    latitude = models.DecimalField(max_digits=9, decimal_places=6, blank=True, null=True)
+    longitude = models.DecimalField(max_digits=9, decimal_places=6, blank=True, null=True)
 
+    def set_long_and_lat(self):
+        location = self.post_code + self.address_2
+        result = geocoder.arcgis(location).json
+        if result is not None:
+            self.latitude = round(result['lat'], 6)
+            self.longitude = round(result['lng'], 6)
+
+    # Overriding save, to set long & lat points from postcode entered
+    def save(self, *args, **kwargs):
+        self.set_long_and_lat()
+        super(Venue, self).save(*args, **kwargs)
 
     def __str__(self):
         return '{0} - created at: {1}'.format(self.name, self.created_at)


### PR DESCRIPTION
### What change does this PR introduce?

_Explain why this PR exists_
* on save the long and lat values of the venue is calculated
  using the `address_2` and `postcode` fields
* then the values are saved into their respective fields
### Notes

_Instructions on how to run this locally, background context, what to review, questions…_
`docker-compose -f local.yml build`
`docker-compose -f local.yml up `
### Ticket

- [Trello Ticket](https://trello.com/c/DjSIiy9o/71-automatically-geo-locate-post-codes-location-on-save-of-venue)

### Screenshots
![Screenshot from 2020-07-21 23-51-53](https://user-images.githubusercontent.com/38472867/88115094-4bd12580-cbad-11ea-8905-b52ef9bd6a1f.png)

_Visuals that may help the reviewer_
