### PR TITLE
venue image bg-position and bg-size changed

### DIFF
--- a/src/styles/components/_venue.scss
+++ b/src/styles/components/_venue.scss
@@ -10,7 +10,8 @@
         height: 600px;
         background-color: $color-provincial-pink;
         background-repeat: no-repeat;
-        background-size: contain;
+        background-position: right 20% bottom 50%;
+        background-size: cover;
 
         // tablet 770x - 615px,
         @media only screen and (min-width: 615px) and (max-width:770px) {


### PR DESCRIPTION
- [ ] This PR follows [contributing quidelines](CONTRIBUTING.md)
- [ ] This PR has tests (for backend in particular)


### What change does this PR introduce?

Styled venue image with background-size and background-position

### Notes

_Instructions on how to run this locally, background context, what to review, questions…_

### Ticket

- [Trello Ticket](https://trello.com/c/JmLtICWF/79-style-venue-hero-venue-image-address)

### Screenshots

<img width="334" alt="Screenshot 2021-01-31 at 16 43 36" src="https://user-images.githubusercontent.com/27692549/106391134-b9bf9a80-63e3-11eb-9916-2ad4ae46471d.png">

<img width="676" alt="Screenshot 2021-01-31 at 16 44 01" src="https://user-images.githubusercontent.com/27692549/106391164-dfe53a80-63e3-11eb-83d7-7aa6500761c8.png">

<img width="755" alt="Screenshot 2021-01-31 at 16 44 10" src="https://user-images.githubusercontent.com/27692549/106391171-ea073900-63e3-11eb-8e18-5cbb5d006729.png">
