### PR TITLE
redo venue styles, added inline style for venue_img

### DIFF
--- a/src/styles/components/_venue.scss
+++ b/src/styles/components/_venue.scss
@@ -10,8 +10,7 @@
         height: 600px;
         background-color: $color-provincial-pink;
         background-repeat: no-repeat;
-        background-position: right 20% bottom 50%;
-        background-size: cover;
+        background-size: contain;
 
         // tablet 770x - 615px,
         @media only screen and (min-width: 615px) and (max-width:770px) {


### PR DESCRIPTION
- [ ] This PR follows [contributing quidelines](CONTRIBUTING.md)
- [ ] This PR has tests (for backend in particular)


### What change does this PR introduce?

- Venue image styles redone
- Added inline styles for sourcing venue image
- Added files for venue_img section and venue_info-address

### Notes

npm run build

### Ticket

- [Trello Ticket](https://trello.com/c/JmLtICWF/79-style-venue-hero-venue-image-address)

### Screenshots

<img width="341" alt="Screenshot 2021-01-31 at 23 44 16" src="https://user-images.githubusercontent.com/27692549/106402477-8996ec80-6421-11eb-9aa0-27a77e5af4a4.png">

<img width="577" alt="Screenshot 2021-01-31 at 23 44 31" src="https://user-images.githubusercontent.com/27692549/106402483-9287be00-6421-11eb-833c-5949e43bc3af.png">


<img width="734" alt="Screenshot 2021-01-31 at 23 44 43" src="https://user-images.githubusercontent.com/27692549/106402493-9ca9bc80-6421-11eb-90a8-5c2dfb23bb94.png">

