### PR TITLE
docs: install docker compose instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Run the tests with `pytest`
 2. **Text Editor**: [Sublime Text](http://www.sublimetext.com/) or your preferred one.
 3. [Docker Desktop](https://www.docker.com/products/docker-desktop)
 4. [Node.js](https://nodejs.org/en/)
+5. If you are NOT using a Mac (e.g. you are using Windows or Linux) then install [Docker Compose](https://docs.docker.com/compose/install/).
+
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,13 @@ Run the tests with `pytest`
 2. **Text Editor**: [Sublime Text](http://www.sublimetext.com/) or your preferred one.
 3. [Docker Desktop](https://www.docker.com/products/docker-desktop)
 4. [Node.js](https://nodejs.org/en/)
-5. If you are NOT using a Mac (e.g. you are using Windows or Linux) then install [Docker Compose](https://docs.docker.com/compose/install/).
 
 
 ## Getting started
 
 Download and install [Docker Desktop](https://www.docker.com/products/docker-desktop) if you haven't already.
+
+ If you are NOT using a Mac (e.g. you are using Windows or Linux) then install [Docker Compose](https://docs.docker.com/compose/install/).
 
 Download and install [Node.js](https://nodejs.org/en/) if you haven't already.
 


### PR DESCRIPTION
- [ ] This PR follows [contributing guidelines](CONTRIBUTING.md)
- [ ] This PR has tests (for backend in particular)


### What change does this PR introduce?

Add install docker compose instruction for developers not using mac (e.g. using Windows or Linux)

### Notes

No Trello ticket but as suggested in a [pull request comment](https://github.com/PolyglotDevsLondon/sharespots/pull/114#discussion_r571458166)

### Screenshots

<img width="366" alt="Screenshot 2021-02-07 at 09 39 34" src="https://user-images.githubusercontent.com/6807448/107142685-7f488700-6928-11eb-8f59-ce071e23c487.png">
