### PR TITLE
fixed styles for titles at homepage header

### DIFF
--- a/src/styles/base/_variables.scss
+++ b/src/styles/base/_variables.scss
@@ -45,7 +45,7 @@ $h4-heading-font: $heading-font !default;
 $h5-heading-font: $heading-font !default;
 
 // Title Font
-$title-font-size: 96px;
+$title-font-size: 36px;
 
 $base-font-size: (
     base: 16,

--- a/src/styles/components/_section.scss
+++ b/src/styles/components/_section.scss
@@ -1,54 +1,69 @@
 .section {
-	align-items: center;
-
-	&-wrap {
-		width: 100%;
-	}
 
 	h1 {
 		color: $color-white;
-		margin: 0;
+		font-size: $title-font-size;
 	}
 
 	&--hero {
-		background-color: $color-pink;
-		height: 450px;
 		display: flex;
-		padding-left: 55px;
+		justify-content: space-around;
+		align-items: center;
+		text-align: center;
+		flex-wrap: wrap;
+		margin: 0;
+		padding: 10px;
+		background-color: $color-pink;
 
 		h1 {
 			font-family: $heading-font;
-			font-size: $title-font-size;
-			text-align: left;
-			margin-bottom: auto;
-			width: 100%;
-			font-size: 62px;
-			font-weight: 300;
+			font-weight: 400;
+			margin-bottom: 0;
+
+			//Tablet
+			@media screen and (min-width: 468px){
+				font-size: 62px;
+			}
 
 			//Desktop
 			@media screen and (min-width: 1024px) {
 				font-size: 96px;
-
 			}
 
 		}
 
 		h2 {
 			font-family: $h2-heading-font;
-			font-size: 28px;
-			text-align: left;
-			max-width: 450px;
-			width: 100%;
+			font-size: 20px;
 			font-weight: 300;
+			max-width: 270px;
+
+			//Tablet
+			@media screen and (min-width: 468px){
+				font-size: 28px;
+				max-width: 360px;
+			}
 
 			//Desktop
 			@media screen and (min-width: 1024px) {
 				font-size: 36px;
+				max-width: 420px;
 			}
+
+		}
+
+		//Tablet 
+		@media screen and (min-width: 768px){
+			display: block;
+			text-align: left;
+			height: 400px;
+		}
+		//Desktop
+		@media screen and (min-width: 1024px){
+			height: 600px;
 		}
 
 		&--primary {
-			background-color: $color-pink;
 			padding: 55px;
 
 			h1 {

--- a/templates/base.html
+++ b/templates/base.html
@@ -2,17 +2,11 @@
 
 <!DOCTYPE html>
 <html lang="en-gb">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
   <head>
-    <title>{% block title %} {% endblock %}| Share Spots</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{% block title %} {% endblock %}| Sharespots</title>
     <!-- Latest compiled and minified CSS -->
-  </head>
-
-  <body>
-    {% block layout %} {% endblock %}
-
-    <script src="{% static 'main.js' %}" type="module"></script>
     <link
       href="https://fonts.googleapis.com/css?family=Monoton|Roboto"
       rel="stylesheet"
@@ -23,6 +17,13 @@
       rel="stylesheet"
       type="text/css"
     />
+    <script src="{% static 'main.js' %}" type="module"></script>
+  </head>
+
+  <body>
+    {% block layout %} {% endblock %}
+
+ 
 
     {% if venue_detail.latitude %}
 

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -8,8 +8,8 @@
 <section class='section section--hero'>
 	<div class="section-wrap">
 		<div class="container">
-			<h1>sharespots</h1>
-			<h2>Find your perfect spot to work together</h2>
+			<h1>Sharespots</h1>
+			<h2>Find co-working friendly cafes in London</h2>
 		</div>
 	</div>
 </section>


### PR DESCRIPTION
- [X] This PR follows [contributing quidelines](CONTRIBUTING.md)
- [ ] This PR has tests (for backend in particular)


### What change does this PR introduce?

1. Changed title font variable
2. Fixed styles for the header's title and subtitle
3. Tidied up <head> tag in the base.html
4. Fixed header text according to Figma styles

### Notes

npm run build

### Ticket

- [Trello Ticket](https://trello.com/c/K5Vx1aXH/121-fix-broken-header-styles-at-homepage)

### Screenshots

mobile
<img width="320" alt="mobile" src="https://user-images.githubusercontent.com/27692549/107410339-136f4580-6b05-11eb-9c38-0924be4088e4.png">

tablet
<img width="570" alt="Tablet" src="https://user-images.githubusercontent.com/27692549/107410359-1c601700-6b05-11eb-8864-a20773eab9ad.png">

desktop
<img width="1200" alt="Desktop" src="https://user-images.githubusercontent.com/27692549/107410383-24b85200-6b05-11eb-9150-4b2af5a9263e.png">
