### PR TITLE
venue map heading styles

### DIFF
--- a/src/styles/components/_venue.scss
+++ b/src/styles/components/_venue.scss
@@ -97,6 +97,17 @@
         padding: 60px;
         background-color: $color-provincial-pink;
     }
+
+    &_map h3 {
+        font-family: $subheading-font;
+        font-size: 20px;
+        font-weight: 700;
+        text-align: center;
+
+        @media (min-width: 468px) {
+            font-size: 28px;
+        }
+    }
 }
 
 .venue_slogan {


### PR DESCRIPTION
- [X] This PR follows [contributing quidelines](CONTRIBUTING.md)
- [ ] This PR has tests (for backend in particular)


### What change does this PR introduce?

Venue map heading centred

### Notes

npm run build

### Ticket

- [Trello Ticket](https://trello.com/c/5gK9r9bb/98-add-map-to-the-venue-page)

### Screenshots

<img width="1172" alt="venue map heading" src="https://user-images.githubusercontent.com/27692549/107445797-0cf8c200-6b35-11eb-9557-a0dba28e4695.png">
