### PR TITLE
feat/link-to-marketing

### DIFF
--- a/src/styles/components/_about_us.scss
+++ b/src/styles/components/_about_us.scss
@@ -1,0 +1,5 @@
+.about_us {
+  a {
+    text-decoration: underline;
+  }
+}

--- a/src/styles/styles.scss
+++ b/src/styles/styles.scss
@@ -19,6 +19,7 @@
 @import "components/layout";
 @import "components/search";
 @import "components/star";
+@import "components/about_us";
 @import "components/venue";
 @import "components/hero";
 @import "components/amenity_rating";

--- a/templates/core/about_us.html
+++ b/templates/core/about_us.html
@@ -6,13 +6,13 @@
 
 {% block main %}
 
-<section class="section section--primary">
+<section class="section section--primary about_us">
     <div class="section-wrap">
         <div class="container">
             <h1>About Us.</h1>
             <h2>Volunteer led project to curate co-working venues
                 around London.</h2>
-            <p>This project is created &amp; maintained by <a href="https://twitter.com/devs_london">Polyglot Devs
+            <p>This project is created &amp; maintained by <a href="https://nostalgic-boyd-16b3b2.netlify.app/">Polyglot Devs
                     London</a>: a
                 London based coding
                 group providing mentorship and support to individuals keen to

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -8,7 +8,7 @@
         <nav class='navbar_header'>
             <a href="{% url 'homepage' %}" class='navbar_header-item {% if request.resolver_match.url_name == "homepage" %}active{% endif %}'>Home</a>
             <a href="{% url 'about' %}" class='navbar_header-item {% if request.resolver_match.url_name == "about" %}active{% endif %}'>About</a>
-            <a href="{% url 'contact' %}" class='navbar_header-item {% if request.resolver_match.url_name == "contact" %}active{% endif %}'>Contact</a>
+            <a href="https://nostalgic-boyd-16b3b2.netlify.app/contact" class='navbar_header-item'>Contact</a>
         </nav>
     </div>
 </header>


### PR DESCRIPTION
- [ ] This PR follows [contributing quidelines](CONTRIBUTING.md)
- [x] This PR has tests (for backend in particular)


### What change does this PR introduce?

To make the about us page and the contact link in the menu more useful by making links to the marketing site.

### Notes

Run the front-end normally.

```npm run dev```

### Ticket

- [Trello Ticket](https://trello.com/c/ecvdwPl2/124-update-menu-links)

### Screenshots

<img width="447" alt="Screenshot 2021-02-13 at 20 50 25" src="https://user-images.githubusercontent.com/6807448/107861324-1f2c7600-6e3d-11eb-96fe-5fc36930670c.png">

