### PR TITLE
add Tweak styles for the venue quote and description section

### DIFF
--- a/src/styles/components/_venue.scss
+++ b/src/styles/components/_venue.scss
@@ -28,7 +28,7 @@
 
   p {
     line-height: 12px;
-    font-family: "Roboto";
+    font-family: 'Roboto';
     font-weight: 400;
   }
 
@@ -156,8 +156,19 @@
   }
 
   &_description {
-    padding: 60px;
+    p {
+      font-size: 16px;
+    }
+
     background-color: $color-provincial-pink;
+    padding: 60px 30px;
+
+    @media (min-width: 1023px) {
+      text-align: center;
+      p {
+        margin-top: 0;
+      }
+    }
   }
 
   &_map h3 {
@@ -173,14 +184,18 @@
 }
 
 .venue_slogan {
+  h2 {
+    font-size: 28px;
+  }
   width: 100%;
   text-align: center;
   display: inline-block;
   margin: 0 auto;
-  padding: 60px 60px 0px 60px;
+  padding: 60px 20px 60px 20px;
   background-color: $color-white;
 
-  @media (min-width: 1023px) {
+  @media (min-width: 768px) {
     background-color: $color-provincial-pink;
+    padding: 60px 60px 0px 60px;
   }
 }

--- a/templates/core/venue.html
+++ b/templates/core/venue.html
@@ -31,7 +31,7 @@
 <section>
     <div class="venue_slogan">
         <div class='container'>
-            <h3>“{{ venue_detail.slogan }}”</h3>
+            <h2>“{{ venue_detail.slogan }}”</h2>
         </div>
     </div>
     <div class="venue_description">


### PR DESCRIPTION
https://trello.com/c/UpydU5o4/114-tweak-styles-for-the-venue-quote-description-section

### What change does this PR introduce?

Tweak styles for the venue quote and description section

### Notes

In a terminal run:

1. docker-compose -f local.yml up to have our project up and running
2. npm run build to apply new style

### Ticket

- [Trello Ticket](https://trello.com/c/UpydU5o4/114-tweak-styles-for-the-venue-quote-description-section)

Screen shots:
<img width="1085" alt="Screenshot 2021-02-13 at 12 14 56" src="https://user-images.githubusercontent.com/8350140/107849876-0cdb1980-6df6-11eb-8cd0-95f72ceee53f.png">

<img width="445" alt="Screenshot 2021-02-13 at 12 13 37" src="https://user-images.githubusercontent.com/8350140/107849883-14022780-6df6-11eb-9717-2c3a860b1f45.png">